### PR TITLE
Fixed Changed event sending same new and old values

### DIFF
--- a/src/Stater/init.lua
+++ b/src/Stater/init.lua
@@ -214,8 +214,9 @@ function Stater:SetState(State: string)
         EndOption(self.Return)
     end
 
-    self.State = State
-    self.Changed:Fire(State, self.State)
+	local OldState = self.State
+	self.State = State
+	self.Changed:Fire(State, OldState)
 end
 
 --[=[


### PR DESCRIPTION
Added a new `oldState` variable to store changes before applying to the State container. This resolves the issue with the Changed observer receiving two same values for the `New` and `Old` state parameters